### PR TITLE
Refactor of converter methods, and make nested view works

### DIFF
--- a/builder/converter/column_mapping.py
+++ b/builder/converter/column_mapping.py
@@ -6,4 +6,4 @@ mapping = {
     'last_failure': 'hudson.views.LastFailureColumn',
     'last_duration': 'hudson.views.LastDurationColumn',
     'build_button': 'hudson.views.BuildButtonColumn'
-    }
+}

--- a/builder/converter/converter.py
+++ b/builder/converter/converter.py
@@ -1,10 +1,21 @@
 import yaml
 from converter_mapping import converters
+import xml.etree.ElementTree as ET
+
 
 def convert_to_xml(yaml_str):
     yaml_dict = yaml.load(yaml_str)
+    yaml_view = yaml_dict[0]['view']
+    view_name = yaml_view['name']
+
+    xml = convert_yaml_dict_to_xml(yaml_view)
+    xml_str = ET.tostring(xml, method='xml', encoding="us-ascii")
+    return (view_name, "<?xml version=\"1.0\" ?>" + xml_str)
+
+
+def convert_yaml_dict_to_xml(yaml_dict):
     try:
-        view_type = yaml_dict[0]['view']['type']
+        view_type = yaml_dict['type']
     except:
         raise Exception('View type %s not supported' % view_type)
-    return converters[view_type](yaml_str)
+    return converters[view_type](yaml_dict)

--- a/builder/converter/converter_mapping.py
+++ b/builder/converter/converter_mapping.py
@@ -6,4 +6,4 @@ converters = {
     'list': list_view.convert_to_xml,
     'pipeline': pipeline_view.convert_to_xml,
     'nested': nested_view.convert_to_xml
-    }
+}

--- a/builder/converter/list_view.py
+++ b/builder/converter/list_view.py
@@ -1,58 +1,77 @@
-import yaml
 import os
-import xml.etree.ElementTree as ET
 from column_mapping import mapping
+import xml.etree.ElementTree as ET
 
 
-def convert_to_xml(yaml_str):
-    yaml_dict = yaml.load(yaml_str)
+def convert_to_xml(yaml_dict):
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    template_path = os.path.join(current_dir,
-                                 'templates/list_view_template.xml')
+    template_path = os.path.join(current_dir, 'templates/list_view_template.xml')
     root = ET.parse(template_path).getroot()
+
     set_name(root, yaml_dict)
     set_description(root, yaml_dict)
     set_jobs(root, yaml_dict)
     set_columns(root, yaml_dict)
     set_recurse(root, yaml_dict)
-    xml = ET.tostring(root, method='xml', encoding="us-ascii")
-    return (yaml_dict[0]['view']['name'],
-            "<?xml version=\"1.0\" ?>" + xml)
+    set_regex(root, yaml_dict)
+
+    return root
 
 
 def set_name(root, yaml_dict):
     name = root.find('name')
-    name.text = yaml_dict[0]['view']['name']
+    name.text = yaml_dict['name']
 
 
 def set_description(root, yaml_dict):
-    if yaml_dict[0]['view']['description']:
+    if 'description' in yaml_dict:
         element = ET.Element('description')
-        element.text = yaml_dict[0]['view']['description']
+        element.text = yaml_dict['description']
         root.append(element)
 
 
 def set_jobs(root, yaml_dict):
-    jobs_section = root.find('jobNames')
-    jobs = yaml_dict[0]['view']['jobs']
-    job_elements = [create_job_element(job)
-                    for job in jobs]
-    for element in job_elements:
-        jobs_section.append(element)
+    if 'jobs' in yaml_dict:
+        jobs_section = root.find('jobNames')
+        jobs = yaml_dict['jobs']
+        job_elements = [create_job_element(job) for job in jobs]
+        for element in job_elements:
+            jobs_section.append(element)
 
 
 def set_columns(root, yaml_dict):
+    columns = []
+    if 'columns' not in yaml_dict:
+        columns = [
+            'status',
+            'weather',
+            'job',
+            'last_success',
+            'last_failure',
+            'last_duration',
+            'build_button'
+        ]
+    else:
+        columns = yaml_dict['columns']
+
     columns_section = root.find('columns')
-    columns = yaml_dict[0]['view']['columns']
-    column_elements = [create_column_element(column)
-                       for column in columns]
+    column_elements = [create_column_element(column) for column in columns]
     for element in column_elements:
         columns_section.append(element)
 
 
 def set_recurse(root, yaml_dict):
+    if 'recurse' not in yaml_dict:
+        return
     recurse = root.find('recurse')
-    recurse.text = 'true' if yaml_dict[0]['view']['recurse'] else 'false'
+    recurse.text = 'true' if yaml_dict['recurse'] else 'false'
+
+
+def set_regex(root, yaml_dict):
+    if 'includeRegex' in yaml_dict:
+        element = ET.Element('includeRegex')
+        element.text = yaml_dict['includeRegex']
+        root.append(element)
 
 
 def create_column_element(column):

--- a/builder/converter/pipeline_view.py
+++ b/builder/converter/pipeline_view.py
@@ -1,75 +1,61 @@
-import yaml
 import os
 import xml.etree.ElementTree as ET
 
 
-def convert_to_xml(yaml_str):
-    yaml_dict = yaml.load(yaml_str)
+def convert_to_xml(yaml_dict):
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    template_path = os.path.join(
-        current_dir, 'templates/pipeline_view_template.xml')
+    template_path = os.path.join(current_dir, 'templates/pipeline_view_template.xml')
     root = ET.parse(template_path).getroot()
+
     set_name(root, yaml_dict)
     set_title(root, yaml_dict)
     set_first_job(root, yaml_dict)
     set_displayed_builds(root, yaml_dict)
     set_refresh_frequency(root, yaml_dict)
-    set_trigger_only_latest(root, yaml_dict)
     set_pipeline_params(root, yaml_dict)
-    set_allow_manual_trigger(root, yaml_dict)
-    xml = ET.tostring(root, method='xml', encoding="us-ascii")
-    return (yaml_dict[0]['view']['name'],
-            "<?xml version=\"1.0\" ?>" + xml)
+
+    return root
 
 
 def set_name(root, yaml_dict):
     name = root.find('name')
-    name.text = yaml_dict[0]['view']['name']
+    name.text = yaml_dict['name']
 
 
 def set_title(root, yaml_dict):
     title = root.find('buildViewTitle')
-    title.text = yaml_dict[0]['view']['title']
+    title.text = yaml_dict.get('title', yaml_dict['name'])
 
 
 def set_first_job(root, yaml_dict):
+    if 'first_job' not in yaml_dict:
+        raise Exception("Missing 'first_job' parameter for pipeline view.")
+
     first_job = root.find('gridBuilder/firstJob')
-    first_job.text = yaml_dict[0]['view']['first_job']
+    first_job.text = yaml_dict['first_job']
 
 
 def set_displayed_builds(root, yaml_dict):
     displayed_builds = root.find('noOfDisplayedBuilds')
-    displayed_builds.text = str(yaml_dict[0]['view']['no_of_displayed_builds'])
+    displayed_builds.text = str(yaml_dict.get('no_of_displayed_builds', 1))
 
 
 def set_refresh_frequency(root, yaml_dict):
     refresh_frequency = root.find('refreshFrequency')
-    refresh_frequency.text = str(yaml_dict[0]['view']['refresh_frequency'])
-
-
-def set_trigger_only_latest(root, yaml_dict):
-    trigger_only_latest = root.find('triggerOnlyLatestJob')
-    trigger_only_latest.text = 'true' if str(
-        yaml_dict[0]['view']['trigger_only_latest']) else 'false'
+    refresh_frequency.text = str(yaml_dict.get('refresh_frequency', 3))
 
 
 def set_pipeline_params(root, yaml_dict):
+    trigger_only_latest = root.find('triggerOnlyLatestJob')
+    allow_manual_trigger = root.find('alwaysAllowManualTrigger')
     show_pipeline_params = root.find('showPipelineParameters')
-    starts_with_params = root.find('startsWithParameters')
     show_pipeline_params_headers = root.find('showPipelineParametersInHeaders')
     show_pipeline_defn_header = root.find('showPipelineDefinitionHeader')
+    starts_with_params = root.find('startsWithParameters')
 
-    view = yaml_dict[0]['view']
-
-    show_pipeline_params.text = str(view['show_pipeline_parameters']).lower()
-    starts_with_params.text = str(view['starts_with_parameters']).lower()
-    show_pipeline_params_headers.text = str(
-        view['show_pipeline_parameters_in_headers']).lower()
-    show_pipeline_defn_header.text = str(
-        view['show_pipeline_definition_header']).lower()
-
-
-def set_allow_manual_trigger(root, yaml_dict):
-    allow_manual_trigger = root.find('alwaysAllowManualTrigger')
-    allow_manual_trigger.text = 'true' if str(
-        yaml_dict[0]['view']['always_allow_manual_trigger']) else 'false'
+    trigger_only_latest.text = str(bool(yaml_dict.get('trigger_only_latest', False))).lower()
+    allow_manual_trigger.text = str(bool(yaml_dict.get('always_allow_manual_trigger', False))).lower()
+    show_pipeline_params.text = str(bool(yaml_dict.get('show_pipeline_parameters', False))).lower()
+    show_pipeline_params_headers.text = str(bool(yaml_dict.get('show_pipeline_parameters_in_headers', False))).lower()
+    show_pipeline_defn_header.text = str(bool(yaml_dict.get('show_pipeline_definition_header', False))).lower()
+    starts_with_params.text = str(bool(yaml_dict.get('starts_with_parameters', True))).lower()

--- a/builder/converter/templates/list_view_template.xml
+++ b/builder/converter/templates/list_view_template.xml
@@ -1,1 +1,15 @@
-<?xml version="1.0" ?><listView><owner class="hudson" reference="../../.."/><name></name><filterExecutors>false</filterExecutors><filterQueue>false</filterQueue><properties class="hudson.model.View$PropertyList"/><jobNames><comparator class="hudson.util.CaseInsensitiveComparator"/></jobNames><jobFilters/><columns></columns><recurse>false</recurse></listView>
+<?xml version="1.0" ?>
+<listView>
+    <owner class="hudson" reference="../../.."/>
+    <name></name>
+    <filterExecutors>false</filterExecutors>
+    <filterQueue>false</filterQueue>
+    <properties class="hudson.model.View$PropertyList"/>
+    <jobNames>
+        <comparator class="hudson.util.CaseInsensitiveComparator"/>
+    </jobNames>
+    <jobFilters/>
+    <columns></columns>
+    <recurse>false</recurse>
+    <includeRegex></includeRegex>
+</listView>

--- a/builder/converter/templates/nested_view_template.xml
+++ b/builder/converter/templates/nested_view_template.xml
@@ -2,16 +2,15 @@
 <hudson.plugins.nested__view.NestedView plugin="nested-view@1.14">
   <owner class="hudson" reference="../../.."/>
   <name></name>
-  <title>/</title>
   <filterExecutors>false</filterExecutors>
   <filterQueue>false</filterQueue>
   <properties class="hudson.model.View$PropertyList"/>
-  <views>
-  </views>
+  <defaultView/>
+  <views/>
   <columns>
     <columns>
       <hudson.views.WeatherColumn/>
       <hudson.views.StatusColumn/>
     </columns>
   </columns>
-</hudson.plugins.nested__view.NestedView> 
+</hudson.plugins.nested__view.NestedView>

--- a/builder/main.py
+++ b/builder/main.py
@@ -14,7 +14,7 @@ class JenkinsViewBuilder(App):
             description="Jenkins View Builder",
             version=0.1,
             command_manager=CommandManager('builder.commands'),
-            )
+        )
 
     def initialize_app(self, argv):
         self.log.debug("Initialize app")

--- a/setup.py
+++ b/setup.py
@@ -29,24 +29,33 @@ config = {
 
     'provides': [],
 
-    'install_requires': ['cliff', 'PyYAML', 'argparse', 'cmd2',
-        'prettytable', 'pyparsing', 'six',
-        'stevedore', 'wsgiref', 'requests'],
+    'install_requires': [
+        'cliff',
+        'PyYAML',
+        'argparse',
+        'cmd2',
+        'prettytable',
+        'pyparsing',
+        'six',
+        'stevedore',
+        'wsgiref',
+        'requests'
+    ],
 
     'packages': find_packages(),
     'include_package_data': True,
     'package_data': {'builder.converter.template': ['*.xml']},
 
-    'entry_points' : {
-            'console_scripts' : [
-                    'jenkins-view-builder = builder.main:main',
-                    ],
-            'builder.commands' : [
-                        'simple = builder.commands.simple:Simple',
-                        'update = builder.commands.update:Update',
-                        'test = builder.commands.test:Test',
-                    ],
-        },
+    'entry_points': {
+        'console_scripts': [
+            'jenkins-view-builder = builder.main:main',
+        ],
+        'builder.commands': [
+            'simple = builder.commands.simple:Simple',
+            'update = builder.commands.update:Update',
+            'test = builder.commands.test:Test',
+        ],
+    },
 
 
     'zip_safe': False,

--- a/tests/fixtures/nested_view.yaml
+++ b/tests/fixtures/nested_view.yaml
@@ -1,7 +1,6 @@
 - view:
     type: nested
     name: monsanto
-    title: monsanto
     views:
       - view:
           type: list

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -2,6 +2,7 @@ import os
 from unittest import TestCase
 from builder.converter.converter import convert_to_xml
 
+
 class TestConverter(TestCase):
 
     current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/tests/test_nested_view.py
+++ b/tests/test_nested_view.py
@@ -11,24 +11,12 @@ class TestNestedView(TestCase):
 
     def test_should_have_name_tag_in_view_xml(self):
         yaml_file = open(os.path.join(self.file_path, 'nested_view.yaml'), 'r')
-        
+
         yaml = yaml_file.read()
 
-        name, xml_view = convert_to_xml(yaml)
+        _, xml_view = convert_to_xml(yaml)
         xml_root = ET.fromstring(xml_view)
 
         name = xml_root.find('name')
-
-        self.assertEqual(name.text, 'monsanto')
-
-    def test_should_have_title_tag_in_view_xml(self):
-        yaml_file = open(os.path.join(self.file_path, 'nested_view.yaml'), 'r')
-        
-        yaml = yaml_file.read()
-
-        name, xml_view = convert_to_xml(yaml)
-        xml_root = ET.fromstring(xml_view)
-
-        name = xml_root.find('title')
 
         self.assertEqual(name.text, 'monsanto')


### PR DESCRIPTION
This is a big pull request. It refactors some problems related with pep8, and function calls.
One of the big differences is to reuse
yaml_dict variable that is redefined as yaml_dict[0]['view'], so we don't repeat this verbose and slower dictionary fetch.
